### PR TITLE
Reverting the PUT vs. POST in UpsertPipeline

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package plank
 
 import (
@@ -64,14 +79,8 @@ func (c *Client) GetPipelines(app string) ([]Pipeline, error) {
 // UpsertPipeline creates/updates a pipeline defined in the struct argument.
 func (c *Client) UpsertPipeline(p Pipeline) error {
 	var unused interface{}
-	if p.ID == "" {
-		if err := c.PostWithRetry(c.pipelinesURL(), ApplicationJson, p, &unused); err != nil {
-			return fmt.Errorf("could not create pipeline - %v", err)
-		}
-	} else {
-		if err := c.PutWithRetry(c.pipelinesURL(), ApplicationJson, p, &unused); err != nil {
-			return fmt.Errorf("could not update pipeline - %v", err)
-		}
+	if err := c.PostWithRetry(c.pipelinesURL(), ApplicationJson, p, &unused); err != nil {
+		return fmt.Errorf("could not create pipeline - %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
It's always POST.  Keeping the Put code though, just in case we use it
later.