### PR TITLE
fix(createapp): fix timer for application polling on creation of new app

### DIFF
--- a/applications.go
+++ b/applications.go
@@ -106,7 +106,7 @@ func (c *Client) CreateApplication(a *Application) error {
 // pollAppConfig isn't exposed because not sure it's worth exposing.  Just
 // call GetApplication() if you're expecting it to be there.
 func (c *Client) pollAppConfig(appName string) error {
-	timer := time.NewTimer(c.retryIncrement)
+	timer := time.NewTimer(4 * time.Minute)
 	t := time.NewTicker(5 * time.Second)
 	defer t.Stop()
 	for range t.C {


### PR DESCRIPTION
The default retry increment is being set to 100, which equates to 100 nanoseconds (being of time.Duration type), this value is also used for request retries with exponential backoff. We want to wait much longer for an app to be created, so we need to poll for 4 minutes, every 5 seconds.