### PR TITLE
feat(fiat):  Add ResyncFiat() call

### DIFF
--- a/applications.go
+++ b/applications.go
@@ -94,6 +94,11 @@ func (c *Client) CreateApplication(a *Application) error {
 		return errors.New(fmt.Sprintf("failed to create application: %s", errMsg))
 	}
 
+	// Not worried if ResyncFiat fails -- if ArmoryEndpoints not enabled, this
+	// is a no-op, if it fails, the polling later might still succeed, or we'll
+	// get an error about not being able to retrieve the Application.
+	c.ResyncFiat()
+
 	// This really shouldn't have to be here, but after the task to create an
 	// app is marked complete sometimes the object still doesn't exist. So
 	// after doing the create, and getting back a completion, we still need

--- a/client.go
+++ b/client.go
@@ -30,11 +30,12 @@ import (
 
 // Client for working with API servers that accept and return JSON payloads.
 type Client struct {
-	http           *http.Client
-	retryIncrement time.Duration
-	maxRetry       int
-	URLs           map[string]string
-	FiatUser       string
+	http            *http.Client
+	retryIncrement  time.Duration
+	maxRetry        int
+	URLs            map[string]string
+	FiatUser        string
+	ArmoryEndpoints bool
 }
 
 type ContentType string

--- a/permissions.go
+++ b/permissions.go
@@ -80,3 +80,22 @@ func (c *Client) GetUser(name string) (*User, error) {
 	}
 	return &u, nil
 }
+
+// ResyncFiat calls to Fiat to tell it to resync its cache of applications
+// and permissions.  This uses an endpoint specific to Armory's distribution
+// of Fiat; if ArmoryEndpoints is not set (it's false by default) this is
+// a no-op.
+func (c *Client) ResyncFiat() error {
+	if !c.ArmoryEndpoints {
+		// This only works if Armory endpoints are available
+		return nil
+	}
+
+	if c.FiatUser == "" {
+		// No FiatUser, no Fiat, do nothing.
+		return nil
+	}
+
+	var unused interface{}
+	return c.Post(c.URLs["fiat"]+"/all", ApplicationJson, nil, &unused)
+}

--- a/permissions.go
+++ b/permissions.go
@@ -97,5 +97,5 @@ func (c *Client) ResyncFiat() error {
 	}
 
 	var unused interface{}
-	return c.Post(c.URLs["fiat"]+"/all", ApplicationJson, nil, &unused)
+	return c.Post(c.URLs["fiat"]+"/forceRefresh/all", ApplicationJson, nil, &unused)
 }


### PR DESCRIPTION
This Armory-specific addition to Fiat will force Fiat to resync its
cache of applications and permissions.  This may help "find" new
applications created by Dinghy when there's otherwise a delay waiting
for Fiat to refresh.