### PR TITLE
feat(client): return body of 4xx errors on put/post requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,33 @@ vendor/
 
 # vim temp files
 *.swp 
+
+# Created by https://www.gitignore.io/api/vim
+# Edit at https://www.gitignore.io/?templates=vim
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+# End of https://www.gitignore.io/api/vim

--- a/client.go
+++ b/client.go
@@ -177,13 +177,24 @@ func (c *Client) Get(url string, dest interface{}) error {
 		}
 		return nil
 	}
-	return &ErrUnsupportedStatusCode{Code:resp.StatusCode}
+	return &ErrUnsupportedStatusCode{Code: resp.StatusCode}
 }
 
 func (c *Client) GetWithRetry(url string, dest interface{}) error {
 	return c.RequestWithRetry(func() error {
 		return c.Get(url, dest)
 	})
+}
+
+// FailedResponse captures a 4xx/5xx response from the upstream Spinnaker service.
+// It is expected that the caller destructures the response according to the structure they expect.
+type FailedResponse struct {
+	Response   []byte
+	StatusCode int
+}
+
+func (e *FailedResponse) Error() string {
+	return fmt.Sprintf("%v: %v", e.StatusCode, e.Response)
 }
 
 // Post a JSON payload from the URL then decode it into the 'dest' arguement.
@@ -212,8 +223,8 @@ func (c *Client) Post(url string, contentType ContentType, body interface{}, des
 	}
 	defer resp.Body.Close()
 
+	b, err := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -227,8 +238,10 @@ func (c *Client) Post(url string, contentType ContentType, body interface{}, des
 			}
 			return nil
 		}
+	} else if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		return &FailedResponse{StatusCode: resp.StatusCode, Response: b}
 	}
-	return &ErrUnsupportedStatusCode{Code:resp.StatusCode}
+	return &ErrUnsupportedStatusCode{Code: resp.StatusCode}
 }
 
 func (c *Client) PostWithRetry(url string, contentType ContentType, body interface{}, dest interface{}) error {
@@ -261,8 +274,8 @@ func (c *Client) Put(url string, contentType ContentType, body interface{}, dest
 	}
 	defer resp.Body.Close()
 
+	b, err := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -276,8 +289,11 @@ func (c *Client) Put(url string, contentType ContentType, body interface{}, dest
 			}
 			return nil
 		}
+	} else if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		return &FailedResponse{StatusCode: resp.StatusCode, Response: b}
 	}
-	return &ErrUnsupportedStatusCode{Code:resp.StatusCode}
+
+	return &ErrUnsupportedStatusCode{Code: resp.StatusCode}
 }
 
 func (c *Client) PutWithRetry(url string, contentType ContentType, body interface{}, dest interface{}) error {
@@ -300,7 +316,7 @@ func (c *Client) Delete(url string) error {
 		// There is no support for receiving a payload back from a DELETE...
 		return nil
 	}
-	return &ErrUnsupportedStatusCode{Code:resp.StatusCode}
+	return &ErrUnsupportedStatusCode{Code: resp.StatusCode}
 }
 
 func (c *Client) DeleteWithRetry(url string) error {

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Seems like a safe change to unmarshall to a common bad request error. If
we can't unmarshall successfully then continue to return the existing
"unsupported error status" message. If we have more time we can return
to this and make it a bit more user friendly.

When merged, this will unlock drastically better error messages for
existing dinghy users by returning validation errors when policy engine
is enabled.

Also updates gomod and adds vim ignore items to .gitignore.