### PR TITLE
chore(docs): update release instructions and add changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @armory/ico

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Summary of Changes
+
+Your summary goes here!
+
+### PR Checklist
+
+Make sure the following checklist items are done before merging this PR.
+
+- [ ] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
+- [ ] Make sure tests are passing
+
+[instructions here]: https://keepachangelog.com/en/1.0.0/#how

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [1.3.0] - 2020-02-25
+### Added
+- `plank.Put` and `plank.Post` methods have learned how to return response
+paylods from 4xx and 5xx responses in the `plank.FailedResponse` struct.
+  - This allows the caller to unmarshall the response payload into whatever
+  struct makes sense for the context.
+
+[Unreleased]: https://github.com/armory/plank/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/armory/plank/compare/v1.2.1...v1.3.0

--- a/README.md
+++ b/README.md
@@ -47,4 +47,25 @@ pipelines, err := client.GetPipelines(app.Name)
 // etc...
 ```
 
+## Development
 
+Build the project:
+
+```
+$ go build
+```
+
+Test the project:
+
+```
+$ go test
+```
+
+### Cutting a New Release
+
+1. Update the [CHANGELOG.md]'s `##Unreleased` section with the next version and
+today's date in `YYYY-MM-DD` format.
+  - Don't forget to update the release URL so that it's easy to diff what was
+  changed (look at the bottom of the CHANGELOG for existing examples).
+1. `git tag vx.x.x` where `x.x.x` is the version you're releasing,
+and `git push --tags` to make sure it's persisted to the project.


### PR DESCRIPTION
The pull request template and auto-reviewers will not trigger on this PR, but will on subsequent PRs. Also adds changelog. When we merge this tomorrow I'll tag and create PRs for armory/dinghy and armory-io/dinghy.