### PR TITLE
feat(app): add application lifecycle methods, update pipeline defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @armory/ico
+*.md @armory/docs-team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.0.0] - 2020-03-19
+### Added
+
+- `plank.Client` has learned how to _update_ and _delete_ Application objects
+- `plank.Client` has learned how to make `PATCH` requests to Spinnaker services.
+
+### Changed
+
+- `plank.Application` objects have learned how to make the following fields
+optional: `DataSourceType`, `PermissionsType`
+  - If you weren't explicitly setting these fields then they will be ommitted
+  from the request made to Spinnaker.  If you want to preserve existing behavior
+  you can initialize these fields like so:
+
+```go
+app := plank.Application{}
+
+// To set an empty datasourcetype
+app.DataSources = &plank.DataSourceType{}
+
+// To set an empty permissions block
+app.Permissions = &plank.PermissionsType{}
+```
+
+- `plank.Pipeline` objects have learned how to make locking pipeline UI edits
+optional.
+  - Previous behavior required you to _opt out_ of locking pipelines changes
+  in the UI. If you'd like to preserve this behavior make sure your objects
+  are calling `Lock()` before passing them to `plank.Client`:
+
+```go
+p := plank.Pipeline{}
+p.Lock() // UI edits will now be disallowed
+
+// ... create pipeline via plank.Client
+```
+
+### Fixed
+
+### Removed
+
+
 ## [1.3.0] - 2020-02-25
 ### Added
 - `plank.Put` and `plank.Post` methods have learned how to return response

--- a/applications.go
+++ b/applications.go
@@ -44,12 +44,12 @@ type PermissionsType struct {
 
 // Application as returned from the Spinnaker API.
 type Application struct {
-	Name        string          `json:"name" mapstructure:"name" yaml:"name" hcl:"name"`
-	Email       string          `json:"email" mapstructure:"email" yaml:"email" hcl:"email"`
-	Description string          `json:"description,omitempty" mapstructure:"description" yaml:"description,omitempty" hcl:"description,omitempty"`
-	User        string          `json:"user,omitempty" mapstructure:"user" yaml:"user,omitempty" hcl:"user,omitempty"`
-	DataSources DataSourcesType `json:"dataSources,omitempty" mapstructure:"dataSources" yaml:"datasources,omitempty" hcl:"datasources,omitempty"`
-	Permissions PermissionsType `json:"permissions,omitempty" mapstructure:"permissions" yaml:"permissions,omitempty" hcl:"permissions,omitempty"`
+	Name        string           `json:"name" mapstructure:"name" yaml:"name" hcl:"name"`
+	Email       string           `json:"email" mapstructure:"email" yaml:"email" hcl:"email"`
+	Description string           `json:"description,omitempty" mapstructure:"description" yaml:"description,omitempty" hcl:"description,omitempty"`
+	User        string           `json:"user,omitempty" mapstructure:"user" yaml:"user,omitempty" hcl:"user,omitempty"`
+	DataSources *DataSourcesType `json:"dataSources,omitempty" mapstructure:"dataSources" yaml:"datasources,omitempty" hcl:"datasources,omitempty"`
+	Permissions *PermissionsType `json:"permissions,omitempty" mapstructure:"permissions" yaml:"permissions,omitempty" hcl:"permissions,omitempty"`
 }
 
 // GetApplication returns the Application data struct for the
@@ -69,6 +69,20 @@ func (c *Client) GetApplications() (*[]Application, error) {
 		return nil, err
 	}
 	return &apps, nil
+}
+
+// DeleteApplication deletes an application from the configured front50 store.
+func (c *Client) DeleteApplication(name string) error {
+	return c.Delete(fmt.Sprintf("%s/v2/applications/%s", c.URLs["front50"], name))
+}
+
+// UpdateApplication updates an application in the configured front50 store.
+func (c *Client) UpdateApplication(app Application) error {
+	var unused interface{}
+	if err := c.PatchWithRetry(fmt.Sprintf("%s/v2/applications/%s", c.URLs["front50"], app.Name), ApplicationJson, app, &unused); err != nil {
+		return fmt.Errorf("could not update application %q: %w", app.Name, err)
+	}
+	return nil
 }
 
 type createApplicationTask struct {

--- a/pipelines.go
+++ b/pipelines.go
@@ -39,7 +39,7 @@ type Pipeline struct {
 	LastModifiedBy       string                   `json:"lastModifiedBy" yaml:"lastModifiedBy" hcl:"lastModifiedBy"`
 	Config               interface{}              `json:"config,omitempty" yaml:"config,omitempty" hcl:"config,omitempty"`
 	UpdateTs             string                   `json:"updateTs" yaml:"updateTs" hcl:"updateTs"`
-	Locked               PipelineLockType         `json:"locked,omitempty" yaml:"locked,omitempty" hcl:"locked,omitempty"`
+	Locked               *PipelineLockType        `json:"locked,omitempty" yaml:"locked,omitempty" hcl:"locked,omitempty"`
 }
 
 type PipelineLockType struct {
@@ -48,8 +48,10 @@ type PipelineLockType struct {
 }
 
 func (p *Pipeline) Lock() *Pipeline {
-	p.Locked.UI = true
-	p.Locked.AllowUnlockUI = true
+	p.Locked = &PipelineLockType{
+		UI:            true,
+		AllowUnlockUI: true,
+	}
 	return p
 }
 


### PR DESCRIPTION
### Summary of Changes

Adding application lifecycle functions (update/delete) that our need in the `pacrd` experiment project. Made backwards incompatible changes to default fields that were previously required (application permissions/data sources, pipeline locks).

When we merge this PR I will tag master with `2.0.0`.

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [x] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how
