### PR TITLE
feat(client): default endpoints should be localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- `plank.Client` change the defaults URLs from `armory-orca` etc to `localhost` as it's more common to do `kubectl port-forwards` for each service locally.
-- `plank.Client` has the cient option `WithURLs` renamed to `WithOverrideAllURLs` to make it more obvious what this function is doing
+- (breaking change) `plank.Client` change the defaults URLs from `armory-orca` etc to `localhost` as it's more common to do `kubectl port-forwards` for each service locally.
+- (breaking change) `plank.Client` has the cient option `WithURLs` renamed to `WithOverrideAllURLs` to make it more obvious what this function is doing
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `plank.Client` change the defaults URLs from `armory-orca` etc to `localhost` as it's more common to do `kubectl port-forwards` for each service locally.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `plank.Client` change the defaults URLs from `armory-orca` etc to `localhost` as it's more common to do `kubectl port-forwards` for each service locally.
+- `plank.Client` `WithURLs` renamed to `WithOverrideAllURLs` to make it more obvious what this function is doing
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `plank.Client` change the defaults URLs from `armory-orca` etc to `localhost` as it's more common to do `kubectl port-forwards` for each service locally.
-- `plank.Client` `WithURLs` renamed to `WithOverrideAllURLs` to make it more obvious what this function is doing
+- `plank.Client` has the cient option `WithURLs` renamed to `WithOverrideAllURLs` to make it more obvious what this function is doing
 
 ### Fixed
 

--- a/applications_test.go
+++ b/applications_test.go
@@ -26,7 +26,7 @@ import (
 func TestGetApplication(t *testing.T) {
 	payload := `{"name":"testapp","email":"foo@bar.com"}`
 	client := NewTestClient(func(req *http.Request) *http.Response {
-		assert.Equal(t, req.URL.String(), "http://armory-front50:8080/v2/applications/foo")
+		assert.Equal(t, req.URL.String(), "http://localhost:8080/v2/applications/foo")
 		return &http.Response{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(payload)),
@@ -48,13 +48,13 @@ func TestCreateApp(t *testing.T) {
 	client := NewTestClient(func(req *http.Request) *http.Response {
 		var payload string
 		switch req.URL.String() {
-		case "http://armory-orca:8083/ops":
+		case "http://localhost:8083/ops":
 			assert.Equal(t, req.Method, "POST")
 			payload = postPayload
-		case "http://armory-orca:8083/refstring":
+		case "http://localhost:8083/refstring":
 			assert.Equal(t, req.Method, "GET")
 			payload = pollTaskPayload
-		case "http://armory-front50:8080/v2/applications/foo":
+		case "http://localhost:8080/v2/applications/foo":
 			payload = appPayload
 		default:
 			assert.Fail(t, "Unexpected URL requested: "+req.URL.String())

--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func WithFiatUser(user string) ClientOption {
 	}
 }
 
-func WithURLs(urls map[string]string) ClientOption {
+func WithOverrideAllURLs(urls map[string]string) ClientOption {
 	return func(c *Client) {
 		c.URLs = make(map[string]string)
 		for k, v := range urls {

--- a/client.go
+++ b/client.go
@@ -100,10 +100,10 @@ func WithURLs(urls map[string]string) ClientOption {
 
 // DefaultURLs
 var DefaultURLs = map[string]string{
-	"orca":    "http://armory-orca:8083",
-	"front50": "http://armory-front50:8080",
-	"fiat":    "http://armory-fiat:7003",
-	"gate":    "http://armory-gate:8084",
+	"orca":    "http://localhost:8083",
+	"front50": "http://localhost:8080",
+	"fiat":    "http://localhost:7003",
+	"gate":    "http://localhost:8084",
 }
 
 // New constructs a Client using a default client and sane non-shared http transport

--- a/client_test.go
+++ b/client_test.go
@@ -78,7 +78,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, &http.Client{}, test_client.http)
 
 	test_retry_inc := New(WithRetryIncrement(5 * time.Second))
-	assert.Equal(t, 5 * time.Second, test_retry_inc.retryIncrement)
+	assert.Equal(t, 5*time.Second, test_retry_inc.retryIncrement)
 
 	test_fiat := New(WithFiatUser("foo"))
 	assert.Equal(t, "foo", test_fiat.FiatUser)

--- a/client_test.go
+++ b/client_test.go
@@ -86,6 +86,6 @@ func TestOptions(t *testing.T) {
 	test_max_retries := New(WithMaxRetries(5))
 	assert.Equal(t, 5, test_max_retries.maxRetry)
 
-	test_with_urls := New(WithURLs(map[string]string{"foo":"http://foo"}))
-	assert.Equal(t, map[string]string{"foo":"http://foo"}, test_with_urls.URLs)
+	test_with_urls := New(WithOverrideAllURLs(map[string]string{"foo": "http://foo"}))
+	assert.Equal(t, map[string]string{"foo": "http://foo"}, test_with_urls.URLs)
 }

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -27,7 +27,7 @@ import (
 func TestGetUser(t *testing.T) {
 	payload := `{"name":"testapp","admin":true,"accounts":[],"applications":[]}`
 	client := NewTestClient(func(req *http.Request) *http.Response {
-		assert.Equal(t, req.URL.String(), "http://armory-fiat:7003/authorize/foo")
+		assert.Equal(t, req.URL.String(), "http://localhost:7003/authorize/foo")
 		return &http.Response{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(payload)),

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestGetPipelines(t *testing.T) {
 	client := NewTestClient(func(req *http.Request) *http.Response {
-		assert.Equal(t, req.URL.String(), "http://armory-front50:8080/pipelines/myapp")
+		assert.Equal(t, req.URL.String(), "http://localhost:8080/pipelines/myapp")
 		return &http.Response{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),


### PR DESCRIPTION
### Summary of Changes

`localhost` is much more likely than `armory-orca` because we can do kubectl port-forward.

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [x] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how