### PR TITLE
fix(validation): refId warning instead of error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.1.0] 2020-05-25
+### Added
+
+### Changed
+- `plank.ValidateRefIds` for `plank.Pipeline` will return a warning instead of an error when refId is not found for a stage.
+
+### Fixed
+
+### Removed
+
 
 ## [3.0.0] 2020-05-19
 ### Added
@@ -86,6 +96,7 @@ paylods from 4xx and 5xx responses in the `plank.FailedResponse` struct.
   struct makes sense for the context.
 
 [Unreleased]: https://github.com/armory/plank/compare/v1.3.0...HEAD
+[3.1.0]: https://github.com/armory/plank/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/armory/plank/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/armory/plank/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/armory/plank/compare/v1.3.0...v2.0.0

--- a/pipelines.go
+++ b/pipelines.go
@@ -77,7 +77,8 @@ func (p *Pipeline) ValidateRefIds() ValidationResult {
 			if _, exists := stageMap["refId"]; !exists {
 				// Separate this validation as per comment in: https://github.com/armory/plank/pull/69
 				// Card created: ENG-5293
-				validationResult.Errors = append(validationResult.Errors, errors.New("Required refId field not found"))
+				//validationResult.Errors = append(validationResult.Errors, errors.New("Required refId field not found"))
+				validationResult.Warnings = append(validationResult.Warnings, "RefId field not found in stage")
 			} else {
 				refId = stageMap["refId"].(string)
 				if _,exists := refidsSet[refId]; exists {

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -99,8 +99,8 @@ func TestPipeline_ValidateRefIds(t *testing.T) {
 							}
 						]
 					}`,
-					[]string{"Required refId field not found"},
-			[]string{},
+					[]string{},
+			[]string{"RefId field not found in stage"},
 		},
 		"refIds_and_stageref_do_not_exists" : {
 			`{
@@ -117,8 +117,8 @@ func TestPipeline_ValidateRefIds(t *testing.T) {
 							}
 						]
 					}`,
-			[]string{"Required refId field not found","Referenced stage mj1 cannot be found."},
-			[]string{},
+			[]string{"Referenced stage mj1 cannot be found."},
+			[]string{"RefId field not found in stage"},
 		},
 		"refIds_duplicated" : {
 			`{


### PR DESCRIPTION
### Summary of Changes
Changed validation, instead of error for mandatory refId it will be a warning

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [x] Make sure tests are passing

