### PR TITLE
feat(fiat): add permissions evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- FiatPermissionsEvaluator for determining authorization based on User roles with Fiat
+
+```go
+// example usage
+objs := []Foo{
+	{name: "foo1", permisisons: []string{"engineering", "core-eng"}},
+	{name: "foo2", permisisons: []string{"ico-team", "spin-team"}},
+	{name: "foo3", permisisons: []string{"engineering"}},
+}
+
+evaluator := plank.NewFiatPermissionEvaluator(plank.WithOrMode(true))
+
+user := "ethanfrogers"
+
+for _, o := range objs {
+	allowed, err := evaluator.HasReadPermission(user, o)
+	if err != nil {
+		fmt.Printf("error encountered: %s", err.Error())
+		os.Exit(1)
+	}
+	if allowed {
+		fmt.Printf("obj %s allowed\n", o.Name())
+	}
+}
+```
 ### Changed
 
 ### Fixed

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -17,6 +17,7 @@ package plank
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -55,4 +56,148 @@ func TestHasAppWriteAccess(t *testing.T) {
 	assert.True(t, u.HasAppWriteAccess("foo"))
 	assert.False(t, u.HasAppWriteAccess("bar"))
 	assert.False(t, u.HasAppWriteAccess("nonexistent"))
+}
+
+func generateTestClient(t *testing.T, resp interface{}, respCode int, targetEndpoint string) *Client{
+	tc := NewTestClient(func(r *http.Request) *http.Response {
+		assert.Equal(t, r.URL.String(), targetEndpoint)
+		//TODO(ethanfrogers): assert that the X-Spinnaker-User header matches the incoming user
+		b, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("failed to marshal response input: %s", err.Error())
+		}
+		return &http.Response{
+			StatusCode: respCode,
+			Body: ioutil.NopCloser(bytes.NewReader(b)),
+			Header: make(http.Header),
+		}
+	})
+	return New(WithClient(tc))
+}
+
+func TestClient_UserRoles(t *testing.T) {
+	cases := map[string]struct{
+		c *Client
+		expectedOutput []string
+		expectedErr error
+		username string
+	}{
+		"happy path": {
+			username: "armory",
+			c: generateTestClient(t, []FiatRole{{Name: "team-a"}, {Name: "team-b"}}, http.StatusOK, "http://localhost:7003/authorize/armory/roles"),
+			expectedOutput: []string{"team-a", "team-b"},
+			expectedErr: nil,
+		},
+	}
+
+	for testName, c := range cases {
+		t.Run(testName, func(t *testing.T) {
+			out, err := c.c.UserRoles(c.username)
+			assert.Equal(t, c.expectedOutput, out)
+			assert.Nil(t, err)
+		})
+	}
+}
+
+type mockFiatClient struct {
+	rolesReturn []string
+	errReturn error
+}
+
+func (m mockFiatClient) UserRoles(username string) ([]string, error) {
+	return m.rolesReturn, m.errReturn
+}
+
+type mockPermissable struct {
+	permissions []string
+	ReadPermissable
+}
+
+func (m mockPermissable) Permissions() []string {
+	return m.permissions
+}
+
+func TestFiatPermissionEvaluator_HasReadPermission(t *testing.T) {
+	cases := map[string]struct{
+		mockClient mockFiatClient
+		permissable ReadPermissable
+		expectedResult bool
+		orMode bool
+	}{
+		"contains all permissions": {
+			expectedResult: true,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-a", "team-b"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-a", "team-b"},
+			},
+		},
+		"user is missing roles": {
+			expectedResult: false,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-b"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-a", "team-b"},
+			},
+		},
+		"user has different roles": {
+			expectedResult: false,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-c"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-a", "team-b"},
+			},
+		},
+		"permissions has different roles": {
+			expectedResult: false,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-b"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-c", "team-d"},
+			},
+		},
+		"or mode - contains at least 1 role in common": {
+			expectedResult: true,
+			orMode: true,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-b", "team-a"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-c", "team-d", "team-b"},
+			},
+		},
+		"or mode - no overlapping permissions": {
+			expectedResult: false,
+			orMode: true,
+			mockClient: mockFiatClient{
+				rolesReturn: []string{"team-b", "team-a"},
+				errReturn:   nil,
+			},
+			permissable: mockPermissable{
+				permissions:     []string{"team-c", "team-d", "team-e"},
+			},
+		},
+	}
+
+	for testName, c := range cases {
+		t.Run(testName, func(t *testing.T) {
+			cfactory := func(opts ...ClientOption) FiatClient {
+				return c.mockClient
+			}
+			evaluator := &FiatPermissionEvaluator{orMode: c.orMode, clientFactory: cfactory}
+			res, _ := evaluator.HasReadPermission("test", c.permissable)
+			assert.Equal(t, c.expectedResult, res)
+		})
+	}
+
+
 }


### PR DESCRIPTION
add fiat permissions evaluator for use in go based applications. since
we can't extend fiat at this time, we use the roles endpoint to get a
users role and calculate it on the client side. once fiat can be
extended for custom resource types, we'll remove this logic.
ReadPermissable enables us to evaluate permission on any object that
implements the ReadPermissable interface.


### Summary of Changes

Your summary goes here!

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [ ] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how