### PR TITLE
fix(fiat): fix nil check for ReadPermissable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed nil check for `ReadPermissable` interface
 
 ### Removed
 


### PR DESCRIPTION
### Summary of Changes

Since `ReadPermissable` is an interface, a direct nil check using `==` doesn't work. This adds extra logic to determine if the argument passed in a nil pointer.

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [ ] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [ ] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how
