### PR TITLE
fix(pipeline_param): Add parameter for SpEl Expression version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [3.4.5] 2021-1602
+
+### Added
+- Added parameter SpelEvaluator to allow reading this value
+
+### Fixed
+- Fixed a bug in which pipelines with the parameter SpelEvaluator where not being saved with said parameter
+
+### Removed
+
+
 ## [3.4.4] 2020-01-22
 
 ### Added
@@ -182,6 +193,7 @@ paylods from 4xx and 5xx responses in the `plank.FailedResponse` struct.
   struct makes sense for the context.
 
 [Unreleased]: https://github.com/armory/plank/compare/v1.3.0...HEAD
+[3.4.5]: https://github.com/armory/plank/compare/v3.4.4...v3.4.5
 [3.4.4]: https://github.com/armory/plank/compare/v3.4.3...v3.4.4
 [3.4.3]: https://github.com/armory/plank/compare/v3.4.2...v3.4.3
 [3.4.2]: https://github.com/armory/plank/compare/v3.4.1...v3.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [3.4.5] 2021-1602
+## [3.4.5] 2021-16-02
 
 ### Added
 - Added parameter SpelEvaluator to allow reading this value

--- a/pipelines.go
+++ b/pipelines.go
@@ -41,6 +41,7 @@ type Pipeline struct {
 	Config               interface{}              `json:"config,omitempty" yaml:"config,omitempty" hcl:"config,omitempty"`
 	UpdateTs             string                   `json:"updateTs" yaml:"updateTs" hcl:"updateTs"`
 	Locked               *PipelineLockType        `json:"locked,omitempty" yaml:"locked,omitempty" hcl:"locked,omitempty"`
+	SpelEvaluator	     string                   `json:"spelEvaluator" yaml:"spelEvaluator" hcl:"spelEvaluator"`
 }
 
 type PipelineLockType struct {


### PR DESCRIPTION
With the change of in "spelEvaluator" parameter in pipelines, dinghy can't read and parse this value into the created pipelines.