### PR TITLE
feat(enable_gate_endpoints): Adds a flag to send requests to gate rat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added Trace Logging Option, this changed the API contract to allow for a traceparent id to be provided. If you do not 
-  wish to add a trace ID simply pass an empty string, and the header will be omitted.  
+  wish to add a trace ID simply pass an empty string, and the header will be omitted.
+  
+- Added the ability to route traffic through gate rather than directly to the Spinnaker sub-services
 
 ### Fixed
 

--- a/applications.go
+++ b/applications.go
@@ -89,8 +89,14 @@ func (c *Client) GetApplication(name, traceparent string) (*Application, error) 
 // GetApplications returns all applications (you can see, at least)
 func (c *Client) GetApplications(traceparent string) (*[]Application, error) {
 	var apps []Application
-	if err := c.Get(c.URLs["front50"]+"/v2/applications", traceparent, &apps); err != nil {
-		return nil, err
+	if c.UseGate {
+		if err := c.Get(c.URLs["gate"]+"/plank/v2/applications", traceparent, &apps); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := c.Get(c.URLs["front50"]+"/v2/applications", traceparent, &apps); err != nil {
+			return nil, err
+		}
 	}
 	return &apps, nil
 }
@@ -103,9 +109,16 @@ func (c *Client) DeleteApplication(name, traceparent string) error {
 // UpdateApplication updates an application in the configured front50 store.
 func (c *Client) UpdateApplication(app Application, traceparent string) error {
 	var unused interface{}
-	if err := c.PatchWithRetry(fmt.Sprintf("%s/v2/applications/%s", c.URLs["front50"], app.Name),traceparent, ApplicationJson, app, &unused); err != nil {
-		return fmt.Errorf("could not update application %q: %w", app.Name, err)
+	if c.UseGate {
+		if err := c.PatchWithRetry(fmt.Sprintf("%s/plank/v2/applications/%s", c.URLs["gate"], app.Name),traceparent, ApplicationJson, app, &unused); err != nil {
+			return fmt.Errorf("could not update application %q: %w", app.Name, err)
+		}
+	} else {
+		if err := c.PatchWithRetry(fmt.Sprintf("%s/v2/applications/%s", c.URLs["front50"], app.Name),traceparent, ApplicationJson, app, &unused); err != nil {
+			return fmt.Errorf("could not update application %q: %w", app.Name, err)
+		}
 	}
+
 	if err := c.UpdatePermissions(app.Name, traceparent, app.Permissions); err != nil {
 		// UpdatePermissions will print in the log if something failed
 		return err

--- a/applications.go
+++ b/applications.go
@@ -80,8 +80,14 @@ func (a Application) MarshalJSON() ([]byte, error) {
 // given application name.
 func (c *Client) GetApplication(name, traceparent string) (*Application, error) {
 	var app Application
-	if err := c.Get(c.URLs["front50"]+"/v2/applications/"+name, traceparent, &app); err != nil {
-		return nil, err
+	if c.UseGate {
+		if err := c.Get(c.URLs["gate"]+"/plank/v2/applications/"+name, traceparent, &app); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := c.Get(c.URLs["front50"]+"/v2/applications/"+name, traceparent, &app); err != nil {
+			return nil, err
+		}
 	}
 	return &app, nil
 }

--- a/applications_test.go
+++ b/applications_test.go
@@ -42,6 +42,25 @@ func TestGetApplication(t *testing.T) {
 	assert.Equal(t, app.Email, "foo@bar.com")
 }
 
+func TestGetApplicationWithGate(t *testing.T) {
+	payload := `{"name":"testapp","email":"foo@bar.com"}`
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8084/plank/v2/applications/foo")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(payload)),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	app, err := c.GetApplication("foo", "")
+	assert.Nil(t, err)
+	assert.Equal(t, app.Name, "testapp")
+	assert.Equal(t, app.Email, "foo@bar.com")
+}
+
 func TestCreateApp(t *testing.T) {
 	postPayload := `{"ref":"/refstring"}`
 	pollTaskPayload := `{"id":"foo","status":"sure","endTime":42}`

--- a/applications_test.go
+++ b/applications_test.go
@@ -91,6 +91,37 @@ func TestCreateApp(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestCreateAppWithGate(t *testing.T) {
+	postPayload := `{"ref":"refstring"}`
+	pollTaskPayload := `{"id":"foo","status":"sure","endTime":42}`
+	appPayload := `{"name":"testapp","email":"foo@bar.com"}`
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		var payload string
+		switch req.URL.String() {
+		case "http://localhost:8084/plank/ops":
+			assert.Equal(t, req.Method, "POST")
+			payload = postPayload
+		case "http://localhost:8084/plank/refstring":
+			assert.Equal(t, req.Method, "GET")
+			payload = pollTaskPayload
+		case "http://localhost:8084/plank/v2/applications/foo":
+			payload = appPayload
+		default:
+			assert.Fail(t, "Unexpected URL requested: "+req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(payload)),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	err := c.CreateApplication(&Application{Name: "foo", Email: "Bar"}, "")
+	assert.Nil(t, err)
+}
+
 
 func TestApplicationMarshalJSON (t *testing.T){
 	app := Application{

--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	URLs            map[string]string
 	FiatUser        string
 	ArmoryEndpoints bool
+	UseGate         bool
 }
 
 type ContentType string
@@ -128,6 +129,7 @@ func New(opts ...ClientOption) *Client {
 		retryIncrement: 100,
 		maxRetry:       20,
 		URLs:           make(map[string]string),
+		UseGate:        false,
 	}
 	// Have to manually copy the DefaultURLs map because otherwise any changes
 	// made to this copy will modify the global.  I can't believe I have to
@@ -309,4 +311,11 @@ func (c *Client) EnableArmoryEndpoints() {
 
 func (c *Client) DisableARmoryEndpoints() {
 	c.ArmoryEndpoints = false
+}
+
+func (c *Client) UseGateEndpoints() {
+	c.UseGate = true
+}
+func (c *Client) UseServiceEndpoints() {
+	c.UseGate = false
 }

--- a/notifications.go
+++ b/notifications.go
@@ -49,8 +49,14 @@ func (notifications *NotificationsType) ValidateAppNotification() error {
 // GetApplicationNotifications returns all application notifications
 func (c *Client) GetApplicationNotifications(appName, traceparent string) (*NotificationsType, error) {
 	var notifications NotificationsType
-	if err := c.Get(c.URLs["front50"]+"/notifications/application/"+appName, traceparent, &notifications); err != nil {
-		return nil, err
+	if c.UseGate {
+		if err := c.Get(c.URLs["gate"]+"/plank/notifications/application/"+appName, traceparent, &notifications); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := c.Get(c.URLs["front50"]+"/notifications/application/"+appName, traceparent, &notifications); err != nil {
+			return nil, err
+		}
 	}
 	return &notifications, nil
 }
@@ -65,8 +71,14 @@ func (c *Client) UpdateApplicationNotifications(notifications NotificationsType,
 	}
 	notifications.FillAppNotificationFields(appName)
 	var unused interface{}
-	if err := c.Post(fmt.Sprintf("%s/notifications/application/%s", c.URLs["front50"], appName),traceparent, ApplicationJson, notifications , &unused); err != nil {
-		return fmt.Errorf("could not update notifications %q: %w", notifications, err)
+	if c.UseGate {
+		if err := c.Post(fmt.Sprintf("%s/plank/notifications/application/%s", c.URLs["gate"], appName),traceparent, ApplicationJson, notifications , &unused); err != nil {
+			return fmt.Errorf("could not update notifications %q: %w", notifications, err)
+		}
+	} else {
+		if err := c.Post(fmt.Sprintf("%s/notifications/application/%s", c.URLs["front50"], appName),traceparent, ApplicationJson, notifications , &unused); err != nil {
+			return fmt.Errorf("could not update notifications %q: %w", notifications, err)
+		}
 	}
 	return nil
 }

--- a/permissions.go
+++ b/permissions.go
@@ -100,7 +100,12 @@ func (c *Client) ResyncFiat(traceparent string) error {
 	}
 
 	var unused interface{}
-	return c.Post(c.URLs["fiat"]+"/forceRefresh/all",traceparent, ApplicationJson, nil, &unused)
+	if c.UseGate {
+		return c.Post(c.URLs["gate"]+"/plank/forceRefresh/all",traceparent, ApplicationJson, nil, &unused)
+	} else {
+		return c.Post(c.URLs["fiat"]+"/forceRefresh/all",traceparent, ApplicationJson, nil, &unused)
+	}
+
 }
 
 type FiatRole struct {

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -41,6 +41,23 @@ func TestGetPipelines(t *testing.T) {
 	assert.Equal(t, len(val), 0) // Should get 0 pipelines back.
 }
 
+func TestGetPipelinesWithGate(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8084/plank/pipelines/myapp")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	val, err := c.GetPipelines("myapp", "")
+	assert.Nil(t, err)
+	assert.Equal(t, len(val), 0) // Should get 0 pipelines back.
+}
+
 func TestPipeline_ValidateRefIds(t *testing.T) {
 	tests := map[string]struct {
 		stage           string

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -58,6 +58,72 @@ func TestGetPipelinesWithGate(t *testing.T) {
 	assert.Equal(t, len(val), 0) // Should get 0 pipelines back.
 }
 
+func TestUpsertPipelinesNoIdWithGate(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8084/plank/pipelines")
+		assert.Equal(t, req.Method, "POST")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	err := c.UpsertPipeline(Pipeline{},"", "")
+	assert.Nil(t, err)
+}
+
+func TestUpsertPipelinesWithGate(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8084/plank/pipelines/Test")
+		assert.Equal(t, req.Method, "PUT")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	err := c.UpsertPipeline(Pipeline{},"Test", "")
+	assert.Nil(t, err)
+}
+
+func TestUpsertPipelines(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8080/pipelines/Test")
+		assert.Equal(t, req.Method, "PUT")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	err := c.UpsertPipeline(Pipeline{},"Test", "")
+	assert.Nil(t, err)
+}
+
+func TestUpsertPipelinesNoId(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8080/pipelines")
+		assert.Equal(t, req.Method, "POST")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	err := c.UpsertPipeline(Pipeline{},"", "")
+	assert.Nil(t, err)
+}
+
 func TestPipeline_ValidateRefIds(t *testing.T) {
 	tests := map[string]struct {
 		stage           string

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -124,6 +124,39 @@ func TestUpsertPipelinesNoId(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDeletePipelines(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8080/pipelines/test-App/appName")
+		assert.Equal(t, req.Method, "DELETE")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	err := c.DeletePipeline(Pipeline{Application: "test-App", Name: "appName"}, "")
+	assert.Nil(t, err)
+}
+
+func TestDeletePipelinesWithGate(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		assert.Equal(t, req.URL.String(), "http://localhost:8084/plank/pipelines/test-App/appName")
+		assert.Equal(t, req.Method, "DELETE")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("[]")),
+			Header:     make(http.Header),
+		}
+	})
+
+	c := New(WithClient(client))
+	c.UseGateEndpoints()
+	err := c.DeletePipeline(Pipeline{Application: "test-App", Name: "appName"}, "")
+	assert.Nil(t, err)
+}
+
 func TestPipeline_ValidateRefIds(t *testing.T) {
 	tests := map[string]struct {
 		stage           string


### PR DESCRIPTION
…her than directly to internal Spinnaker services

### Summary of Changes

Adds the ability to confiure plank to direct calls to gate instead of directly to the consuming services. 

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [x] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how
