### PR TITLE
client: set fiat auth user for delete pipelines request 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [4.1.4]
+### Fixed
+- In Delete stale pipelines getting 403 access denied due to no fiat user header set 
 
 ## [4.1.3]
 

--- a/client.go
+++ b/client.go
@@ -280,6 +280,10 @@ func (c *Client) Delete(url, traceparent string) error {
 	if err != nil {
 		return err
 	}
+	if c.FiatUser != "" {
+	   request.Header.Set(SpinFiatUserHeader, c.FiatUser)
+	   request.Header.Set(SpinFiatAccountHeader, c.FiatUser)
+	}
 	if traceparent != "" {
 		request.Header.Set("traceparent", traceparent)
 	}


### PR DESCRIPTION


### Summary of Changes

all request going via wrapper `request` but delete function deleting stale pipelines directly and was missing header for fiat user

### PR Checklist

Make sure the following checklist items are done before merging this PR.

- [x] Update `CHANGELOG.md` in the `## Unreleased` section ([instructions here])
- [x] Make sure tests are passing

[instructions here]: https://keepachangelog.com/en/1.0.0/#how
